### PR TITLE
Question for Chidi (line 44 of server_test.js)

### DIFF
--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -22,7 +22,6 @@ const getAllItems = async (tableName) => {
 
 
 const addNewItem = async(tableName, requestBody) => {
-    console.log("reached addNewItem"); //test
     validateTableName(tableName);
 
     const newItem = buildNewItem(requestBody);

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -1,5 +1,4 @@
 const getAllFromDatabase = async (pool, tableName) => {
-    // console.log("getAllFromDatabase function"); //test
     const client = await pool.connect();  
     var result;
     const query = 'SELECT * FROM ' + tableName;
@@ -20,13 +19,10 @@ const getAllFromDatabase = async (pool, tableName) => {
 
 // CURRENTLY WIP 
 const addToDatabase = async (pool, tableName, newItem) => {
-    console.log("reached addToDatabase"); //test
     const client = await pool.connect();  
     var addedItem;
     //for field in new item, append to a string, with "," between each 
     const query = `INSERT INTO ${tableName} (${newItem.columns}) VALUES (${newItem.values}) RETURNING *`;
-    
-    console.log("before try look in add to db"); //test
     try {
         addedItem = await client.query(query);
     } catch (error) {
@@ -34,7 +30,8 @@ const addToDatabase = async (pool, tableName, newItem) => {
         throw error; //how to handle specific types of errors? Probably in future iteration
     };
     client.release();
-    return addedItem; 
+    return addedItem; //previously returned this but might have to return .rows 
+ 
     // return { id: 3, category_name: "Vegetables" }
 }
 

--- a/src/routes/categoriesRouter.js
+++ b/src/routes/categoriesRouter.js
@@ -22,6 +22,8 @@ categoriesRouter.get("/", async (req, res, next) => {
 //get specific item
 
 
+
+//currently working on making this actually call the addNewItem function 
 categoriesRouter.post("/", jsonParser, validateNewCategory, async (req, res, next) => {
     var response;
     // console.log(req.body); //test


### PR DESCRIPTION
Chidi, 

My endpoint tests suddenly seem to be more of integration tests than unit tests. 

I am trying to update the post endpoints logic (e.g. in categoriesRouter) with the correct implementation that calls the addNewItem and addToDatabase functions, and I've just realised that my current endpoint tests are actually sending these values to the database. 

If you look at my Post endpoint tests and my categoriesRouter file, it seems that the only reason why they currently aren't changing the database is that I haven't implemented the call to the addNewItem function. 

I believe that in order to keep these tests correct, they must not affect my actual database. I have one idea on how to go about this: 
    1) Mock database. Pro: The tests won't affect my actual database. Con: I feel its too early for this to take place in the development process. It also seems to be more complicated than necessary.

I'd love your opinion on this. How should I think about testing my endpoints without making it an integration test? Am I thinking about this in the right way? Is there something I'm not yet aware of?